### PR TITLE
Handle bad test data (no nested array)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
   - "7"
 script:
   - npm run lint
-  - npm run coverage-cc
+  - npm run coverage
   - npm run examples

--- a/lib/unroll.js
+++ b/lib/unroll.js
@@ -86,6 +86,15 @@ function unroll (title, testFunc, unrolledValues) {
     return value;
   };
 
+  if (unrolledValues[0].constructor !== Array) {
+    throw (new Error(
+      'You specified unroll, but did not specify any unrolledItems. ' +
+      ' unrolledKeys=' + JSON.stringify(unrolledKeys) +
+      ' unrolledItems=' + JSON.stringify(unrolledItems) +
+      ' Check your values (is it a nested array?).'
+    ));
+  }
+
   unrolledItems.forEach(function (unrolled) {
     var unrolledTestName = title;
     var unrolledArgs = {};

--- a/test/specs/unrollSpec.js
+++ b/test/specs/unrollSpec.js
@@ -325,6 +325,28 @@ describe('unroll()', function () {
 
       done();
     });
+
+    it('with unrolled values not wrapper in an array', function (done) {
+      var error = '';
+
+      try {
+        unroll(testTitle,
+          function () {},
+          ['foo', 'baz'],
+          ['x', 'y']
+        );
+      } catch (e) {
+        error = e.toString();
+      }
+
+      expect(spy.called);
+      expect(spy.threw());
+      expect(error).to.contain(
+        'nested array'
+      );
+
+      done();
+    });
   });
 
   describe('.use()', function () {

--- a/test/specs/unrollSpec.js
+++ b/test/specs/unrollSpec.js
@@ -326,7 +326,7 @@ describe('unroll()', function () {
       done();
     });
 
-    it('with unrolled values not wrapper in an array', function (done) {
+    it('with unrolled values not wrapped in an array', function (done) {
       var error = '';
 
       try {


### PR DESCRIPTION
**What**
Throw an error when unroll doesn't specify unrolledValues as nested array else test will not execute

**Why**
If you don't nest the data in an array, it won't run your unroll test and silently keep going.

See also: https://github.com/lawrencec/Unroll/issues/30

Alternatively, instead of throwing an error, we could just log it was a warning if there is a concern.
I also tried this in a small node app with Jasmine and it threw the Error as expected.
