### PR TITLE
Feature/data tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: node_js
 node_js:
   - "7"
+dist: trusty
+sudo: false
+addons:
+  chrome: stable
+before_install:
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 script:
-  - npm run lint
-  - npm run coverage
-  - npm run examples
+  - npm run ci

--- a/README.md
+++ b/README.md
@@ -51,6 +51,40 @@ Note the use of `#` character to prefix parameter name and the additional argume
         );
     });
 
+The data table can also be specified using a template literal if nested arrays aren't your thing. For example the above can be written
+like so when using template literals.
+
+    ```
+	describe('maximum of two numbers (unrolled)', function() {
+        unroll('maximum of #a and #b is #c',
+          function(done, testArgs) {
+            expect(
+              Math.max(testArgs['a'], testArgs['b'])
+            ).to.be.equal(testArgs['c']);
+            done();
+          },
+          `
+            where:
+            a   |   b   |   c
+            3   |   5   |   5
+            7   |   0   |   7
+          `
+        );
+    });
+
+Note, that objects and arrays need to be stringified first:
+
+    ```
+    unroll('The #thing was jumped over by #entity.',
+        () => {},
+        `
+          where:
+          entity                            |   thing
+          cat                               |   moon
+          1                                 |   2
+          ${JSON.stringify({name: 'cat'})}  |   ${JSON.stringify({name: 'moon'})}
+        `
+      );
 
 ## Examples
 

--- a/lib/unroll.js
+++ b/lib/unroll.js
@@ -1,124 +1,183 @@
-var grammar;
+let grammar;
+
+const isString = function (value) {
+  return typeof value === 'string';
+};
+
+const throwIfNotAString = function (value) {
+  const isStringifed = isStringifiedJSON(value);
+  if (value && (!isString(value) || isStringifed)) {
+    let errorValue = (isStringifed) ? value : JSON.stringify(value);
+    throw (new Error(`Incorrect type for arg:"${errorValue}" - must be a string`));
+  }
+};
+
+const isStringifiedJSON = function (value) {
+  try {
+    JSON.parse(value);
+  } catch (e) {
+    return false;
+  }
+  return true;
+};
+
+const parseValue = function (value) {
+  try {
+    return JSON.parse(value.match(/\[.*?\]/) ? value.slice(0) : value);
+  } catch (e) {
+    return value;
+  }
+};
+
+const throwIfNoMatch = function (value, matcher) {
+  if (!value.match(matcher)) {
+    throw (
+      new Error(`Incorrect value for arg:"${JSON.stringify(value)}" - requires "${matcher.toString().replace(/(\/)/g, '')}"`)
+    );
+  }
+};
+
+function throwifNotNestedArray (data) {
+  if (data[0].constructor !== Array) {
+    throw (new Error(
+      `You specified unroll, but did not specify any unrolledItems.
+       unroll=' + ${JSON.stringify(data)} 
+       Check your values (is it a nested array?).`
+    ));
+  }
+}
+
+function extractDataFromDataArray (data) {
+  throwifNotNestedArray(data);
+  return {variableNames: data.slice(0, 1)[0], variableValues: data.slice(1)};
+}
+
+function extractDataFromDataTable (data) {
+  throwIfNoMatch(data, /where:/);
+  const dataRows = data
+    .split(/\r?\n/)
+    .filter(function (row) {
+      return !(row.trim().match(/where:/)) && row.trim();
+    });
+
+  const variableNames = dataRows[0]
+    .split('|')
+    .map(function (variableName) {
+      return variableName.trim();
+    });
+
+  const variableValues = dataRows
+    .slice(1)
+    .map(function (dataRow) {
+      return dataRow.split('|')
+        .map(function (v) {
+          const trimmedValue = v.trim();
+
+          return isString(trimmedValue) && !Number.isNaN(Number(trimmedValue))
+            ? parseFloat(trimmedValue)
+            : trimmedValue;
+        });
+    });
+
+  return {variableNames, variableValues};
+}
+
+function extractData (data) {
+  if (Array.isArray(data)) {
+    return extractDataFromDataArray(data);
+  } else if (isString(data)) {
+    return extractDataFromDataTable(data);
+  } else {
+    throw new Error('unroll data should be a String or an Array. See docs!');
+  }
+}
+
+const extractValue = function (value, arg) {
+  let parsedValue = parseValue(value);
+
+  if (arg.indexOf('.') > 0) {
+    const nestedName = arg.split('.')[1];
+    if (!nestedName || !parsedValue.hasOwnProperty(nestedName)) {
+      throw new Error(`${nestedName} not found in arg: ${JSON.stringify(parsedValue)}`);
+    }
+    return parsedValue[nestedName];
+  }
+
+  return parsedValue;
+};
+
+const _isES7Async = function isAsync (func) {
+  const string = func.toString().trim();
+
+  return !!(
+    // native
+    string.match(/^async /) ||
+    // babel (this may change)
+    string.match(/return _ref(.*).apply/)
+  );
+};
+
+const isCallbackStyle = function (testFunc) {
+  return testFunc.length === 2;
+};
+
+const getStringValue = function (value) {
+  const type = typeof value;
+  if (type === 'object') {
+    return JSON.stringify(value);
+  } else if (type === 'number') {
+    return value;
+  }
+  return `"${value}"`;
+};
 
 /**
  * parameterizes test functions
  *
  * @param {String} title  title of test with parameterized values
  * @param {Function} testFunc test function
- * @param {Array} unrolledValues data table of values (nested array)
+ * @param {Array|String} unrolledValues data table of values (nested array)
  */
 function unroll (title, testFunc, unrolledValues) {
   if (!grammar) {
-    throw new Error(
-      'No grammar specified: Use unroll.use() to specify test function'
-    );
+    throw new Error('No grammar specified: Use unroll.use() to specify test function');
   }
 
-  var unrolledKeys = unrolledValues.slice(0, 1)[0];
-  var unrolledItems = unrolledValues.slice(1);
-  var _callTestFunc;
-  var _getStringValue;
-  var _throwIfNotAString;
-  var _extractValue;
-  var _isES7Async;
-  var isCallbackStyle;
-
-  _isES7Async = function isAsync (func) {
-    const string = func.toString().trim();
-
-    return !!(
-    // native
-      string.match(/^async /) ||
-        // babel (this may change)
-        string.match(/return _ref(.*).apply/)
-    );
-  };
-
-  isCallbackStyle = function (testFunc) {
-    return testFunc.length === 2;
-  };
-
-  _callTestFunc = function (testFunc, unrolledArgs) {
+  const _callTestFunc = function (testFunc, unrolledArgs) {
     if (_isES7Async(testFunc)) {
-      return function () {
-        return testFunc.apply(this, Array.prototype.slice.apply(arguments).concat(unrolledArgs));
-      };
+      return function () { return testFunc.apply(this, Array.prototype.slice.apply(arguments).concat(unrolledArgs)); };
     } else if (isCallbackStyle(testFunc)) {
-      return function (done) {
-        testFunc(done, unrolledArgs);
-      };
+      return function (done) { testFunc(done, unrolledArgs); };
     }
-    return function () {
-      testFunc(unrolledArgs);
-    };
+    return function () { testFunc(unrolledArgs); };
   };
 
-  _getStringValue = function (value) {
-    var type = typeof value;
-    if (type === 'object') {
-      return JSON.stringify(value);
-    } else if (type === 'number') {
-      return value;
-    }
-    return '"' + value + '"';
-  };
+  const { variableNames, variableValues } = extractData(unrolledValues);
 
-  _throwIfNotAString = function (value) {
-    if (typeof value !== 'string') {
-      throw (new Error(
-        'Incorrect type for arg:"' +
-              JSON.stringify(value) +
-              '" - must be a string')
-      );
-    }
-  };
-
-  _extractValue = function (value, arg) {
-    if (arg.indexOf('.') > 0) {
-      var nestedName = arg.split('.')[1];
-      if (!nestedName || !value.hasOwnProperty(nestedName)) {
-        throw new Error(
-          nestedName + ' not found in arg: ' + JSON.stringify(value)
-        );
-      }
-      return value[nestedName];
-    }
-    return value;
-  };
-
-  if (unrolledValues[0].constructor !== Array) {
-    throw (new Error(
-      'You specified unroll, but did not specify any unrolledItems. ' +
-      ' unrolledKeys=' + JSON.stringify(unrolledKeys) +
-      ' unrolledItems=' + JSON.stringify(unrolledItems) +
-      ' Check your values (is it a nested array?).'
-    ));
-  }
-
-  unrolledItems.forEach(function (unrolled) {
-    var unrolledTestName = title;
-    var unrolledArgs = {};
-    if (unrolled.length !== unrolledKeys.length) {
+  variableValues.forEach(function (unrolled) {
+    let unrolledTestName = title;
+    const unrolledArgs = {};
+    if (unrolled.length !== variableNames.length) {
       throw (new Error('mismatched number of unroll values passed in'));
     }
 
-    unrolledKeys.forEach(function (key, index) {
-      _throwIfNotAString(unrolledKeys[index]);
-      unrolledArgs[key] = unrolled[index];
+    variableNames.forEach(function (key, index) {
+      throwIfNotAString(variableNames[index]);
+      unrolledArgs[key] = parseValue(unrolled[index]);
     });
 
     (unrolledTestName.match(/#\w+(\.\w+)?/g) || [])
       .forEach(
         function (matchedArg) {
-          var unrolledValue = unrolledArgs[matchedArg.replace('#', '').split('.')[0]];
+          let unrolledValue = unrolledArgs[matchedArg.replace('#', '').split('.')[0]];
           if (unrolledValue === null || unrolledValue === undefined) {
             return;
           }
 
-          unrolledValue = _extractValue(unrolledValue, matchedArg);
+          unrolledValue = extractValue(unrolledValue, matchedArg);
           unrolledTestName = unrolledTestName.replace(
             matchedArg,
-            _getStringValue(unrolledValue)
+            getStringValue(unrolledValue)
           );
         }
       );

--- a/package.json
+++ b/package.json
@@ -4,17 +4,18 @@
   "description": "A helper tool to easily iterate through test data against a test method with verbose output about each iteration.",
   "main": "index.js",
   "scripts": {
+    "ci": "npm run lint && npm run test && npm run test-browser && npm run examples && npm run coverage-cc",
     "lint": "eslint lib/**/*.js test/**/*.js examples/**/*.js ./*.js",
-    "test": "mocha -R spec test/specs/*Spec.js",
+    "test": "mocha --reporter spec test/specs/*Spec.js",
     "test-browser": "karma start test/conf/karma.conf",
     "coverage": "mkdir -p ./target; istanbul cover --report lcov --dir ./target node_modules/.bin/_mocha -- -R spec --recursive test/specs/*Spec.js",
     "coverage-cc": "npm run coverage; codeclimate-test-reporter < target/lcov.info",
     "example-ava": "ava --verbose examples/ava/*.js",
-    "example-mocha": "mocha -R spec -u bdd examples/mocha/mocha-bdd-example.js; mocha -R spec -u tdd examples/mocha/mocha-tdd-example.js; mocha -R spec -u qunit examples/mocha/mocha-qunit-example.js",
+    "example-mocha": "mocha -R spec -u bdd examples/mocha/mocha-bdd-example.js && mocha -R spec -u tdd examples/mocha/mocha-tdd-example.js && mocha -R spec -u qunit examples/mocha/mocha-qunit-example.js",
     "example-tape": "tape examples/tape/*.js | tap-spec",
     "example-jasmine": "jasmine JASMINE_CONFIG_PATH=examples/jasmine/jasmine.json",
     "example-jest": "jest examples/jest/",
-    "examples": "npm run example-ava; npm run example-mocha; npm run example-tape; npm run example-jasmine; npm run example-jest"
+    "examples": "npm run example-ava && npm run example-mocha && npm run example-tape && npm run example-jasmine && npm run example-jest"
   },
   "repository": {
     "type": "git",
@@ -41,12 +42,12 @@
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
+    "intelli-espower-loader": "^1.0.1",
     "istanbul": "^0.4.5",
-    "jasmine": "^2.5.2",
+    "jasmine": "^2.8.0",
     "jasmine-reporters": "^2.1.1",
     "jest": "^20.0.4",
     "karma": "^1.3.0",
-    "karma-chai": "^0.1.0",
     "karma-chai-sinon": "^0.1.5",
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.1.1",
@@ -54,9 +55,9 @@
     "karma-mocha": "^1.2.0",
     "karma-spec-reporter": "0.0.31",
     "mocha": "^3.1.2",
-    "sinon": "^3.2.0",
-    "sinon-chai": "^2.12.0",
+    "sinon": "^3.2.1",
+    "sinon-chai": "^2.13.0",
     "tap-spec": "^4.1.1",
-    "tape": "^4.4.0"
+    "tape": "^4.8.0"
   }
 }

--- a/test/conf/karma.conf.js
+++ b/test/conf/karma.conf.js
@@ -59,7 +59,7 @@ module.exports = function (config) {
     // - PhantomJS
     // - IE (only Windows)
     // CLI --browsers Chrome,Firefox,Safari
-    browsers: [process.env.TRAVIS ? 'Chrome' : 'Chrome'],
+    browsers: ['ChromeHeadless'],
 
     // If browser does not capture in given timeout [ms], kill it
     // CLI --capture-timeout 5000

--- a/test/specs/unrollSpec.js
+++ b/test/specs/unrollSpec.js
@@ -4,115 +4,112 @@ var chai = chai || require('chai');
 var sinon = sinon || require('sinon');
 // eslint-disable-next-line no-use-before-define
 var unroll = unroll || require('../../lib/unroll.js');
-
+var assert = chai.assert;
 if (typeof window === 'undefined') {
   var sinonChai = require('sinon-chai');
   chai.use(sinonChai);
 }
-var expect = chai.expect;
 
-describe('unroll()', function () {
-  describe('outputs test title correctly', function () {
-    var testTitle = 'The #entity jumped over the #thing.';
-    var sandbox;
-    var spy;
+const testTitle = 'The #entity jumped over the #thing.';
+let sandbox;
+let testSpy;
 
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create();
-      spy = sandbox.spy(function () {});
-      unroll.use(spy);
-    });
+const match = sinon.match;
+beforeEach(function () {
+  sandbox = sinon.sandbox.create();
+  sinon.assert.expose(assert, { prefix: '' });
+  testSpy = sandbox.spy(function () {});
+  unroll.use(testSpy);
+});
 
-    afterEach(function () {
-      sandbox.restore();
-    });
+afterEach(function () {
+  sandbox.restore();
+});
 
-    it('when correctly called with string values', function (done) {
-      unroll(testTitle,
-        function () {
-
-        },
+// let testSpy;
+//
+// test.beforeEach(function () {
+//   testSpy = spy();
+//   unroll.use(testSpy);
+// });
+describe('unroll()', () => {
+  describe('outputs test title correctly', () => {
+    it('(array.notation) when called with string values', () => {
+      unroll(
+        testTitle,
+        () => {},
         [
           ['entity', 'thing'],
-          ['cat', 'moon']
+          ['cat', 'moon'],
+          ['dog', 'planet']
         ]
       );
-      expect(spy.callCount).to.equal(1);
-      expect(spy.firstCall.args[0])
-        .to
-        .equal('The "cat" jumped over the "moon".');
-      done();
+      assert.callCount(testSpy, 2);
+      assert.calledWithExactly(testSpy, 'The "cat" jumped over the "moon".', match.func);
+      assert.calledWithExactly(testSpy, 'The "dog" jumped over the "planet".', match.func);
     });
 
-    it('when correctly called with object values', function (done) {
-      var testTitle = 'The #entity jumped over the #thing.';
-      unroll(testTitle,
-        function () {},
+    it('(array.notation) when called with object values', () => {
+      unroll(
+        testTitle,
+        () => {},
         [
           ['entity', 'thing'],
-          ['cat', {isAnObject: true}]
+          ['cat', {isAnObject: true}],
+          ['dog', 'planet']
         ]
       );
-      expect(spy.callCount).to.equal(1);
-      expect(spy.firstCall.args[0])
-        .to
-        .equal('The "cat" jumped over the {"isAnObject":true}.');
-      done();
+      assert.callCount(testSpy, 2);
+      assert.calledWithExactly(testSpy, 'The "cat" jumped over the {"isAnObject":true}.', match.func);
+      assert.calledWithExactly(testSpy, 'The "dog" jumped over the "planet".', match.func);
     });
 
-    it('when correctly called with object values and title references subkey',
-      function (done) {
-        var testTitle = 'The #entity jumped over the #thing.name.';
-        unroll(testTitle,
-          function () {},
-          [
-            ['entity', 'thing'],
-            ['cat', {name: 'dog'}]
-          ]
-        );
-        expect(spy.callCount).to.equal(1);
-        expect(spy.firstCall.args[0])
-          .to
-          .equal('The "cat" jumped over the "dog".');
-        done();
-      }
-    );
-
-    it('when correctly called with array values', function (done) {
-      var testTitle = 'The #entity jumped over the #thing.';
-      unroll(testTitle,
-        function () {},
+    it('(array.notation) when called with object values and title references subkey', () => {
+      unroll(
+        'The #entity jumped over the #thing.name.',
+        () => {},
         [
           ['entity', 'thing'],
-          ['cat', [1]]
+          ['cat', {name: 'dog'}]
         ]
       );
-      expect(spy.callCount).to.equal(1);
-      expect(spy.firstCall.args[0])
-        .to
-        .equal('The "cat" jumped over the [1].');
-      done();
+      assert.callCount(testSpy, 1);
+      assert.calledWithExactly(testSpy, 'The "cat" jumped over the "dog".', match.func);
     });
 
-    it('when correctly called with number values', function (done) {
-      var testTitle = 'The #entity jumped over the moon #times times.';
-      unroll(testTitle,
-        function () {},
+    it('(array.notation) when called with array values', () => {
+      unroll(
+        testTitle,
+        () => {},
         [
-          ['entity', 'times'],
-          ['cat', 6]
+          ['entity', 'thing'],
+          ['cat', [1, 2]],
+          ['dog', 'planet']
         ]
       );
-      expect(spy.callCount).to.equal(1);
-      expect(spy.firstCall.args[0])
-        .to
-        .equal('The "cat" jumped over the moon 6 times.');
-      done();
+      assert.callCount(testSpy, 2);
+      assert.calledWithExactly(testSpy, 'The "cat" jumped over the [1,2].', match.func);
+      assert.calledWithExactly(testSpy, 'The "dog" jumped over the "planet".', match.func);
     });
 
-    it('when called with incorrect sequence of testArgs in the title', function () {
-      unroll('The #entity jumped.',
-        function () {},
+    it('(array.notation) when called with number values', () => {
+      unroll(
+        'The maximum value of #a and #b is #c.',
+        () => {},
+        [
+          ['a', 'b', 'c'],
+          [3, 5, 5],
+          [0, 7, 7]
+        ]
+      );
+      assert.callCount(testSpy, 2);
+      assert.calledWith(testSpy, 'The maximum value of 3 and 5 is 5.', match.func);
+      assert.calledWith(testSpy, 'The maximum value of 0 and 7 is 7.', match.func);
+    });
+
+    it('(array.notation) when called with incorrect sequence of testArgs in the title', () => {
+      unroll('The #thing was jumped over by #entity.',
+        () => {},
         [
           ['entity', 'thing'],
           ['cat', 'moon'],
@@ -121,73 +118,229 @@ describe('unroll()', function () {
         ]
       );
 
-      expect(spy.callCount).to.equal(3);
-      expect(spy.firstCall.args[0]).to.equal('The "cat" jumped.');
-      expect(spy.secondCall.args[0]).to.equal('The 1 jumped.');
-      expect(spy.thirdCall.args[0]).to.equal('The {"name":"cat"} jumped.');
+      assert.callCount(testSpy, 3);
+      assert.calledWithExactly(testSpy, 'The "moon" was jumped over by "cat".', match.func);
+      assert.calledWithExactly(testSpy, 'The 2 was jumped over by 1.', match.func);
+      assert.calledWithExactly(testSpy, 'The {"name":"moon"} was jumped over by {"name":"cat"}.', match.func);
+    });
+
+    it('(datatable.notation) when called with string values', () => {
+      unroll(
+        testTitle,
+        () => {},
+        `
+          where:
+          entity  |   thing
+          cat     |   moon
+          dog     |   planet
+        `
+      );
+      assert.callCount(testSpy, 2);
+      assert.calledWithExactly(testSpy, 'The "cat" jumped over the "moon".', match.func);
+      assert.calledWithExactly(testSpy, 'The "dog" jumped over the "planet".', match.func);
+    });
+
+    it('(datatable.notation) when called with object values', () => {
+      unroll(
+        testTitle,
+        () => {},
+        `
+          where:
+          entity  |   thing
+          cat     |   ${JSON.stringify({isAnObject: true})}
+          dog     |   planet
+        `
+      );
+      assert.callCount(testSpy, 2);
+      assert.calledWithExactly(testSpy, 'The "cat" jumped over the {"isAnObject":true}.', match.func);
+      assert.calledWithExactly(testSpy, 'The "dog" jumped over the "planet".', match.func);
+    });
+
+    it('(datatable.notation) when called with object values and title references subkey', () => {
+      unroll(
+        'The #entity jumped over the #thing.name.',
+        () => {},
+        `
+          where:
+          entity  |   thing
+          cat     |   ${JSON.stringify({name: 'dog'})}
+        `
+      );
+      assert.callCount(testSpy, 1);
+      assert.calledWithExactly(testSpy, 'The "cat" jumped over the "dog".', match.func);
+    });
+
+    it('(datatable.notation) when called with array values', () => {
+      unroll(
+        testTitle,
+        () => {},
+        `
+          where:
+          entity  |   thing
+          cat     |   ${JSON.stringify([1, 2])}
+          dog     |   planet
+        `
+      );
+      assert.callCount(testSpy, 2);
+      assert.calledWithExactly(testSpy, 'The "cat" jumped over the [1,2].', match.func);
+      assert.calledWithExactly(testSpy, 'The "dog" jumped over the "planet".', match.func);
+    });
+
+    it('(datatable.notation) when called with number values', () => {
+      unroll(
+        'The maximum value of #a and #b is #c.',
+        () => {},
+        ` 
+          where:
+          a | b | c
+          3.2 | 5.3 | 5.3 
+          7 | 0 | 7
+        `
+      );
+      assert.callCount(testSpy, 2);
+      assert.calledWithExactly(testSpy, 'The maximum value of 3.2 and 5.3 is 5.3.', match.func);
+      assert.calledWithExactly(testSpy, 'The maximum value of 7 and 0 is 7.', match.func);
+    });
+
+    it('(datatable.notation) when called with incorrect sequence of testArgs in the title', () => {
+      unroll('The #thing was jumped over by #entity.',
+        () => {},
+        `
+          where:
+          entity                            |   thing
+          cat                               |   moon
+          1                                 |   2
+          ${JSON.stringify({name: 'cat'})}  |   ${JSON.stringify({name: 'moon'})}
+        `
+      );
+
+      assert.callCount(testSpy, 3);
+      assert.calledWithExactly(testSpy, 'The "moon" was jumped over by "cat".', match.func);
+      assert.calledWithExactly(testSpy, 'The 2 was jumped over by 1.', match.func);
+      assert.calledWithExactly(testSpy, 'The {"name":"moon"} was jumped over by {"name":"cat"}.', match.func);
+    });
+  });
+});
+
+describe('calls the test function', () => {
+  let dummyContainer;
+
+  beforeEach(() => {
+    dummyContainer = {
+      it: function (title, fn) {
+        assert.equal(typeof fn, 'function');
+        fn();
+      }
+    };
+  });
+
+  it(
+    'when no unroll data is passed',
+    () => {
+      unroll.use(dummyContainer.it);
+      const myRoutes = [
+        ['entity', 'thing'],
+        ['cat', 'baby']
+      ];
+
+      unroll(
+        'The #entity jumped over the #thing.',
+        async function (testArgs) {
+          assert.equal(testArgs.entity, 'cat');
+          assert.equal(testArgs.thing, 'baby');
+          await 12;
+        },
+        myRoutes
+      );
+    }
+  );
+
+  it('(array.notation) with unrolled test arguments correctly when testFunc specifies a callback', () => {
+    unroll.use(dummyContainer.it);
+
+    const possibleTitles = [
+      'The #entity jumped over the #thing.',
+      'The #thing was jumped over by the #entity.',
+      'The #entity jumped.',
+      'The #thing was jumped over.',
+      'There was a jump.',
+      ''
+    ];
+
+    const possibleValues = [
+      ['cat', 'moon'],
+      [1, 2],
+      [[1, 2, 3], [4, 5, 6]],
+      [{name: 'cat', type: 'animal'}, {name: 'moon', type: 'object'}]
+    ];
+
+    possibleValues.forEach(function (value) {
+      possibleTitles.forEach(
+        function (title) {
+          unroll(title,
+            function (done, testArgs) {
+              assert.equal(arguments.length, 2);
+              assert.equal(typeof testArgs, 'object');
+              assert.equal(Object.keys(testArgs).length, 2);
+              assert.equal(Object.keys(testArgs).join(','), 'entity,thing');
+              assert.equal(testArgs.entity, value[0]);
+              assert.equal(testArgs.thing, value[1]);
+            },
+            [
+              ['entity', 'thing'],
+              value
+            ]
+          );
+        }
+      );
     });
   });
 
-  describe('calls the test function', function () {
-    var dummyContainer, stub;
+  it('(array.notation) with unrolled test arguments correctly when testFunc does not specify a callback', () => {
+    unroll.use(dummyContainer.it);
 
-    beforeEach(function () {
-      dummyContainer = {
-        it: function () {}
-      };
-      stub = sinon.stub(dummyContainer, 'it').callsFake(function (title, fn) {
-        expect(fn).to.be.a('function');
-        fn();
-      });
-      unroll.use(stub);
+    const possibleTitles = [
+      'The #entity jumped over the #thing.',
+      'The #thing was jumped over by the #entity.',
+      'The #entity jumped.',
+      'The #thing was jumped over.',
+      'There was a jump.',
+      ''
+    ];
+
+    const possibleValues = [
+      ['cat', 'moon'],
+      [1, 2],
+      [[1, 2, 3], [4, 5, 6]],
+      [{name: 'cat', type: 'animal'}, {name: 'moon', type: 'object'}]
+    ];
+
+    possibleValues.forEach(function (value) {
+      possibleTitles.forEach(
+        function (title) {
+          unroll(title,
+            function (testArgs) {
+              assert.equal(arguments.length, 1);
+              assert.equal(typeof testArgs, 'object');
+              assert.equal(Object.keys(testArgs).length, 2);
+              assert.equal(Object.keys(testArgs).join(','), 'entity,thing');
+              assert.equal(testArgs.entity, value[0]);
+              assert.equal(testArgs.thing, value[1]);
+            },
+            [
+              ['entity', 'thing'],
+              value
+            ]
+          );
+        }
+      );
     });
+  });
 
-    afterEach(function () {
-      stub.restore();
-    });
-
-    it('with unrolled test arguments correctly', function (done) {
-      var possibleTitles = [
-        'The #entity jumped over the #thing.',
-        'The #thing was jumped over by the #entity.',
-        'The #entity jumped.',
-        'The #thing was jumped over.',
-        'There was a jump.',
-        ''
-      ];
-
-      var possibleValues = [
-        ['cat', 'moon'],
-        [1, 2],
-        [[1, 2, 3], [4, 5, 6]],
-        [{name: 'cat', type: 'animal'}, {name: 'moon', type: 'object'}]
-      ];
-
-      possibleValues.forEach(function (value) {
-        possibleTitles.forEach(
-          function (title) {
-            unroll(title,
-              function (done, testArgs) {
-                expect(arguments.length).to.equal(2);
-                expect(testArgs).to.be.an('object');
-                expect(Object.keys(testArgs).length).to.equal(2);
-                expect(Object.keys(testArgs).join(',')).to.equal('entity,thing');
-                expect(testArgs.entity).to.equal(value[0]);
-                expect(testArgs.thing).to.equal(value[1]);
-              },
-              [
-                ['entity', 'thing'],
-                value
-              ]
-            );
-          }
-        );
-      });
-
-      done();
-    });
-
-    it('titles are unrolled correctly when unroll args are reused across testcases', function (done) {
+  it(
+    '(array.notation) and titles are unrolled correctly when unroll args are reused across testcases',
+    () => {
+      unroll.use(dummyContainer.it);
       const myRoutes = [
         ['entity', 'thing'],
         ['cat', 'baby']
@@ -196,44 +349,219 @@ describe('unroll()', function () {
       unroll(
         'The #entity jumped over the #thing.',
         function (done, testArgs) {
-          expect(testArgs.entity).to.equal('cat');
-          expect(testArgs.thing).to.equal('baby');
+          assert.equal(testArgs.entity, 'cat');
+          assert.equal(testArgs.thing, 'baby');
         },
         myRoutes
       );
       unroll(
         'The #entity jumped over the #thing.',
         function (done, testArgs) {
-          expect(testArgs.entity).to.equal('cat');
-          expect(testArgs.thing).to.equal('baby');
+          assert.equal(testArgs.entity, 'cat');
+          assert.equal(testArgs.thing, 'baby');
         },
         myRoutes
       );
-      done();
-    });
-  });
+    }
+  );
 
-  describe('throws exception when incorrectly called', function () {
-    var testTitle = 'The #entity jumped over the #thing.';
-    var spy;
+  it(
+    '(array.notation) and titles are unrolled correctly when test function is async',
+    () => {
+      unroll.use(dummyContainer.it);
+      const myRoutes = [
+        ['entity', 'thing'],
+        ['cat', 'baby']
+      ];
 
-    beforeEach(function () {
-      unroll.grammar = null;
-      unroll.use(it);
-      spy = sinon.spy(unroll);
-    });
+      unroll(
+        'The #entity jumped over the #thing.',
+        async function (testArgs) {
+          assert.equal(testArgs.entity, 'cat');
+          assert.equal(testArgs.thing, 'baby');
+          await 12;
+        },
+        myRoutes
+      );
+    }
+  );
 
-    afterEach(function (done) {
-      spy.reset();
-      done();
-    });
+  it(
+    '(datatable.notation) values are unrolled correctly and keep type when a number',
+    () => {
+      unroll.use(dummyContainer.it);
+      const myRoutes = `
+        where:
+        a  | b
+        5  | 7.4
+      `;
 
-    it('with mismatched unroll key/title values', function (done) {
-      var error = '';
+      unroll(
+        '#a and #b.',
+        function (testArgs) {
+          assert.isNumber(testArgs.a);
+          assert.isNumber(testArgs.b);
+          assert.strictEqual(testArgs.a, 5);
+          assert.strictEqual(testArgs.b, 7.4);
+        },
+        myRoutes
+      );
+    }
+  );
+
+  it(
+    '(datatable.notation) values are unrolled correctly and keep type when a string',
+    () => {
+      unroll.use(dummyContainer.it);
+      const myRoutes = `
+        where:
+        a     | b
+        foo   | bar
+      `;
+
+      unroll(
+        '#a and #b.',
+        function (testArgs) {
+          assert.isString(testArgs.a);
+          assert.isString(testArgs.b);
+          assert.strictEqual(testArgs.a, 'foo');
+          assert.strictEqual(testArgs.b, 'bar');
+        },
+        myRoutes
+      );
+    }
+  );
+
+  it(
+    '(datatable.notation) values are unrolled correctly and keep type when an array',
+    () => {
+      unroll.use(dummyContainer.it);
+      const myRoutes = `
+        where:
+        a                             | b
+        ${JSON.stringify(['foo'])}    | ${JSON.stringify(['bar'])}
+      `;
+
+      unroll(
+        '#a and #b.',
+        function (testArgs) {
+          assert.isArray(testArgs.a);
+          assert.isArray(testArgs.b);
+          assert.deepEqual(testArgs.a, ['foo']);
+          assert.deepEqual(testArgs.b, ['bar']);
+        },
+        myRoutes
+      );
+    }
+  );
+
+  it(
+    '(datatable.notation) values are unrolled correctly and keep type when an object',
+    () => {
+      unroll.use(dummyContainer.it);
+      const myRoutes = `
+        where:
+        a                             | b
+        ${JSON.stringify({foo: 1})}    | ${JSON.stringify({bar: 2})}
+      `;
+
+      unroll(
+        '#a and #b.',
+        function (testArgs) {
+          assert.isObject(testArgs.a);
+          assert.isObject(testArgs.b);
+          assert.deepEqual(testArgs.a, {foo: 1});
+          assert.deepEqual(testArgs.b, {bar: 2});
+        },
+        myRoutes
+      );
+    }
+  );
+
+  it(
+    '(datatable.notation) and titles are unrolled correctly when unroll args are reused across testcases',
+    () => {
+      unroll.use(dummyContainer.it);
+
+      unroll(
+        'The #entity jumped over the #thing.',
+        function (done, testArgs) {
+          assert.equal(testArgs.entity, 'cat');
+          assert.equal(testArgs.thing, 'baby');
+        },
+        `
+          where:
+          entity  | thing
+          cat     | baby
+        `
+      );
+      unroll(
+        'The #entity jumped over the #thing.',
+        function (done, testArgs) {
+          assert.equal(testArgs.entity, 'cat');
+          assert.equal(testArgs.thing, 'baby');
+        },
+        `
+          where:
+          entity  | thing
+          cat     | baby
+        `
+      );
+    }
+  );
+
+  it(
+    '(datatable.notation) and titles are unrolled correctly when test function is async',
+    () => {
+      unroll.use(dummyContainer.it);
+      const myRoutes = `
+        where:
+        entity  | thing
+        cat     | baby
+      `;
+
+      unroll(
+        'The #entity jumped over the #thing.',
+        async function (testArgs) {
+          assert.equal(testArgs.entity, 'cat');
+          assert.equal(testArgs.thing, 'baby');
+          await 12;
+        },
+        myRoutes
+      );
+    }
+  );
+});
+
+describe('throws exception', () => {
+  it(
+    'when data is not a string or an array',
+    () => {
+      const testTitle = 'The #entity jumped over the #thing.';
+
+      let error = '';
 
       try {
         unroll(testTitle,
-          function () {},
+          () => {},
+          {}
+        );
+      } catch (e) {
+        error = e.toString();
+      }
+
+      assert.equal(error, 'Error: unroll data should be a String or an Array. See docs!');
+    });
+  it(
+    '(array.notation) when incorrectly called with mismatched unroll key/title values',
+    () => {
+      const testTitle = 'The #entity jumped over the #thing.';
+
+      let error = '';
+
+      try {
+        unroll(testTitle,
+          () => {},
           [
             ['incorrect', 'stuff'],
             ['bar', 'moon']
@@ -243,17 +571,13 @@ describe('unroll()', function () {
         error = e.toString();
       }
 
-      expect(spy.called);
-      expect(spy.threw());
-      expect(error).to.equal(
-        'Error: title not expanded as incorrect args passed in'
-      );
-
-      done();
+      assert.equal(error, 'Error: title not expanded as incorrect args passed in');
     });
 
-    it('with mismatched number of unroll key/title values', function (done) {
-      var error = '';
+  it(
+    '(array.notation) when incorrectly called with mismatched number of unroll key/title values',
+    () => {
+      let error = '';
 
       try {
         unroll(testTitle,
@@ -267,17 +591,14 @@ describe('unroll()', function () {
         error = e.toString();
       }
 
-      expect(spy.called);
-      expect(spy.threw());
-      expect(error).to.equal(
-        'Error: mismatched number of unroll values passed in'
-      );
+      assert.equal(error, 'Error: mismatched number of unroll values passed in');
+    }
+  );
 
-      done();
-    });
-
-    it('with keys that are not of String type', function (done) {
-      var error = '';
+  it(
+    '(array.notation) when incorrectly called with keys that are not of String type',
+    () => {
+      let error = '';
 
       try {
         unroll(testTitle,
@@ -291,19 +612,15 @@ describe('unroll()', function () {
         error = e.toString();
       }
 
-      expect(spy.called);
-      expect(spy.threw());
-      expect(error).to.equal(
-        'Error: Incorrect type for arg:"{"shouldNotBeAnObject":true}"' +
-        ' - must be a string'
-      );
+      assert.equal(error, 'Error: Incorrect type for arg:"{"shouldNotBeAnObject":true}" - must be a string');
+    }
+  );
 
-      done();
-    });
-
-    it('with incorrectly subkey references in title', function (done) {
-      var testTitle = 'The #entity jumped over the #thing.INCORRECT.';
-      var error = '';
+  it(
+    '(array.notation) when incorrectly called with incorrectly subkey references in title',
+    () => {
+      const testTitle = 'The #entity jumped over the #thing.INCORRECT.';
+      let error = '';
 
       try {
         unroll(testTitle,
@@ -317,17 +634,14 @@ describe('unroll()', function () {
         error = e.toString();
       }
 
-      expect(spy.called);
-      expect(spy.threw());
-      expect(error).to.equal(
-        'Error: INCORRECT not found in arg: {"name":"dog"}'
-      );
+      assert.equal(error, 'Error: INCORRECT not found in arg: {"name":"dog"}');
+    }
+  );
 
-      done();
-    });
-
-    it('with unrolled values not wrapped in an array', function (done) {
-      var error = '';
+  it(
+    '(array.notation) with unrolled values not wrapped in an array',
+    () => {
+      let error = '';
 
       try {
         unroll(testTitle,
@@ -339,30 +653,140 @@ describe('unroll()', function () {
         error = e.toString();
       }
 
-      expect(spy.called);
-      expect(spy.threw());
-      expect(error).to.contain(
-        'nested array'
-      );
+      assert.include(error, 'nested array');
+    }
+  );
 
-      done();
-    });
-  });
+  it(
+    '(datatable.notation) when incorrectly called with mismatched unroll key/title values',
+    () => {
+      const testTitle = 'The #entity jumped over the #thing.';
 
-  describe('.use()', function () {
-    beforeEach(function () {
-      unroll.use(null);
-    });
-    var testTitle = 'The #entity jumped over the #thing.';
+      let error = '';
 
-    it('must return the correct specified grammar', function () {
-      var grammar = unroll.use(function () {});
-      expect(grammar).to.be.a('function');
-    });
-
-    it('should use throw error if no grammar specified', function () {
-      var error = '';
       try {
+        unroll(testTitle,
+          () => {},
+          `
+            where:
+            incorrect | stuff
+            bar       | moon
+          `
+        );
+      } catch (e) {
+        error = e.toString();
+      }
+
+      assert.equal(error, 'Error: title not expanded as incorrect args passed in');
+    }
+  );
+
+  it(
+    '(datatable.notation) when incorrectly called with mismatched number of unroll key/title values',
+    () => {
+      let error = '';
+
+      try {
+        unroll(testTitle,
+          function () {},
+          `
+            where:
+            incorrect | stuff,
+            cat
+          `
+        );
+      } catch (e) {
+        error = e.toString();
+      }
+
+      assert.equal(error, 'Error: mismatched number of unroll values passed in');
+    }
+  );
+
+  it(
+    '(datatable.notation) when incorrectly called with keys that are not of String type',
+    () => {
+      let error = '';
+
+      try {
+        unroll(testTitle,
+          function () {},
+          `
+            where:
+            incorrect   | ${JSON.stringify({shouldNotBeAnObject: true})}
+            cat         | dog
+          `
+        );
+      } catch (e) {
+        error = e.toString();
+      }
+
+      assert.equal(error, 'Error: Incorrect type for arg:"{"shouldNotBeAnObject":true}" - must be a string');
+    }
+  );
+
+  it(
+    '(datatables.notation) when incorrectly called with incorrectly subkey references in title',
+    () => {
+      const testTitle = 'The #entity jumped over the #thing.INCORRECT.';
+      let error = '';
+
+      try {
+        unroll(testTitle,
+          function () {},
+          `
+            where:
+            entity  | thing
+            cat     | ${JSON.stringify({name: 'dog'})}
+          `
+        );
+      } catch (e) {
+        error = e.toString();
+      }
+
+      assert.equal(error, 'Error: INCORRECT not found in arg: {"name":"dog"}');
+    }
+  );
+
+  it(
+    '(datatables.notation) when incorrectly called with data does not contain "where:" clause',
+    () => {
+      const testTitle = 'The #entity jumped over the #thing';
+      let error = '';
+
+      try {
+        unroll(testTitle,
+          function () {},
+          `
+            entity  | thing
+            cat     | dog
+          `
+        );
+      } catch (e) {
+        error = e.toString();
+      }
+
+      // assert.equal(error.replace(/\/n/g, ''), 'Error: Incorrect value for arg:""\\n            entity  | thing\\n            cat     | dog\\n          "" - requires "where:');
+      assert.equal(error.indexOf('Error: Incorrect value for arg:'), 0);
+    }
+  );
+});
+
+describe('use()', () => {
+  it(
+    'must return the correct specified grammar',
+    function () {
+      const grammar = unroll.use(function () {});
+      assert.equal(typeof grammar, 'function');
+    }
+  );
+
+  it(
+    '(array.notation) should throw error if no grammar specified',
+    () => {
+      let error = '';
+      try {
+        unroll.use(null);
         unroll(testTitle,
           function () {},
           [
@@ -374,30 +798,41 @@ describe('unroll()', function () {
         error = e.toString();
       }
 
-      expect(error).to.equal(
-        'Error: No grammar specified: Use unroll.use() to specify test function'
-      );
-    });
-  });
+      assert.equal(error, 'Error: No grammar specified: Use unroll.use() to specify test function');
+    }
+  );
 
-  describe('async functions', function () {
-    var sandbox;
-    var spy;
+  it(
+    '(datatable.notation) should throw error if no grammar specified',
+    () => {
+      let error = '';
+      try {
+        unroll.use(null);
+        unroll(testTitle,
+          function () {},
+          `
+            where:
+            entity  | thing
+            cat     | {}
+          `
+        );
+      } catch (e) {
+        error = e.toString();
+      }
 
-    beforeEach(function () {
-      sandbox = sinon.sandbox.create();
-      spy = sandbox.spy();
-      unroll.use(spy);
-    });
+      assert.equal(error, 'Error: No grammar specified: Use unroll.use() to specify test function');
+    }
+  );
+});
 
-    afterEach(function () {
-      sandbox.restore();
-    });
-
-    it('is called correctly', function () {
-      var testTitle = 'The #entity jumped over the moon #times times.';
+describe('async() functions', () => {
+  it(
+    '(array.notation) are called correctly',
+    () => {
+      unroll.use(testSpy);
+      const testTitle = 'The #entity jumped over the moon #times times.';
       unroll(testTitle,
-        async function (testArgs) {
+        async function () {
           await 12;
         },
         [
@@ -405,8 +840,28 @@ describe('unroll()', function () {
           ['cat', 6]
         ]
       );
-      expect(spy.callCount).to.equal(1);
-      expect(spy.firstCall.args[0]).to.equal('The "cat" jumped over the moon 6 times.');
-    });
-  });
+      assert.equal(testSpy.callCount, 1);
+      assert.equal(testSpy.firstCall.args[0], 'The "cat" jumped over the moon 6 times.');
+    }
+  );
+
+  it(
+    '(datatable.notation) are called correctly',
+    () => {
+      unroll.use(testSpy);
+      const testTitle = 'The #entity jumped over the moon #times times.';
+      unroll(testTitle,
+        async function (testArgs) {
+          await 12;
+        },
+        `
+          where:
+          entity  | times
+          cat     |  6
+        `
+      );
+      assert.equal(testSpy.callCount, 1);
+      assert.equal(testSpy.firstCall.args[0], 'The "cat" jumped over the moon 6 times.');
+    }
+  );
 });


### PR DESCRIPTION
This PR provides an additional way to specify data using template literals.

```
	describe('maximum of two numbers (unrolled)', function() {
        unroll('maximum of #a and #b is #c',
          function(done, testArgs) {
            expect(
              Math.max(testArgs['a'], testArgs['b'])
            ).to.be.equal(testArgs['c']);
            done();
          },
          `
            where:
            a   |   b   |   c
            3   |   5   |   5
            7   |   0   |   7
          `
        );
    });